### PR TITLE
Change matic contract

### DIFF
--- a/polygon-mainnet.json
+++ b/polygon-mainnet.json
@@ -48,7 +48,7 @@
     },
     {
       "chainId": 137,
-      "address": "0x0000000000000000000000000000000000001010",
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEe",
       "name": "Matic Token",
       "symbol": "MATIC",
       "decimals": 18,

--- a/polygon-mainnet.json
+++ b/polygon-mainnet.json
@@ -48,7 +48,7 @@
     },
     {
       "chainId": 137,
-      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEe",
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "name": "Matic Token",
       "symbol": "MATIC",
       "decimals": 18,


### PR DESCRIPTION
From 0x:
We recommend using the Native MATIC 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEe
0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE is the contract address to use for native tokens. Each blockchain has its own native token, such as ETH on Ethereum, BNB on Binance Smart Chain, and MATIC on Polygon.

In the case of Ethereum, this contract address is used to represent Ether (ETH) in Ethereum transactions, since ETH is not an ERC20 token. We recommend using the Native token for each chain.